### PR TITLE
正規表現によるルーティングを追加

### DIFF
--- a/Routing/routes.php
+++ b/Routing/routes.php
@@ -1,11 +1,11 @@
 <?php
 
+require __DIR__ . '/../config.php';
+
 // use Helpers\ValidationHelper;
 use Response\HTTPRenderer;
 use Response\Render\HTMLRenderer;
 use Controllers\SnippetController;
-
-
 
 return [
   '/' => function (): HTTPRenderer {
@@ -25,7 +25,7 @@ return [
     return new HTMLRenderer('index');
   },
   // show のルーティング
-  '/([a-zA-Z0-9]{13,})' => function ($token): HTTPRenderer {
+  SHOW_ROUTE_PATTERN => function ($token): HTTPRenderer {
     // $controller = new SnippetController();
     // $controller->show($token);
     return new HTMLRenderer('show');

--- a/config.php
+++ b/config.php
@@ -1,0 +1,3 @@
+<?php
+
+define('SHOW_ROUTE_PATTERN', '/([a-zA-Z0-9]{13,})');

--- a/index.php
+++ b/index.php
@@ -1,10 +1,8 @@
 <?php
 
-$DEBUG = true;
+require __DIR__ . '/config.php';
 
-// 以下2行: chatgdpのコード
-// index.php が読み込まれると、Routing/routes.php が読み込まれ実行される
-// require __DIR__ . '/Routing/routes.php';
+$DEBUG = true;
 
 // recursion のコード
 spl_autoload_extensions(file_extensions: ".php");
@@ -20,33 +18,40 @@ $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 if (isset($routes[$path])) {
   // コールバックを呼び出してrendererを作成します。
   $renderer = $routes[$path]();
-
-  try {
-    // ヘッダーを設定します。
-    foreach ($renderer->getFields() as $name => $value) {
-      // ヘッダーに対する単純な検証を実行します。
-      $sanitized_value = filter_var($value, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES);
-
-      if ($sanitized_value && $sanitized_value === $value) {
-        header("{$name}: {$sanitized_value}");
-      } else {
-        // ヘッダー設定に失敗した場合、ログに記録するか処理します。
-        // エラー処理によっては、例外をスローするか、デフォルトのまま続行することもできます。
-        http_response_code(500);
-        if ($DEBUG) print("Failed setting header - original: '$value', sanitized: '$sanitized_value'");
-        exit;
-      }
-
-      print($renderer->getContent());
-    }
-  } catch (Exception $e) {
-    http_response_code(500);
-    print("Internal error, please contact the admin.<br>");
-    if ($DEBUG) print($e->getMessage());
-  }
+  setHeadersAndRenderContent($renderer, $DEBUG);
+} else if (preg_match("#^" . SHOW_ROUTE_PATTERN . "$#", $path, $matches)) {
+  $renderer = $routes[SHOW_ROUTE_PATTERN](...$matches);
+  setHeadersAndRenderContent($renderer, $DEBUG);
 } else {
   // 一致するルートがない場合、404エラーを表示する
   http_response_code(404);
   echo "404 Not Found: The requested route was not found on this server.";
   printf("<br>debug info:<br>%s<br>%s", json_encode($routes), $path);
+}
+
+function setHeadersAndRenderContent($renderer, $DEBUG)
+{
+  try {
+    // ヘッダーを設定
+    foreach ($renderer->getFields() as $name => $value) {
+      // ヘッダーに対する単純な検証を実行
+      $sanitized_value = filter_var($value, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES);
+
+      if ($sanitized_value && $sanitized_value === $value) {
+        header("{$name}: {$sanitized_value}");
+      } else {
+        // ヘッダー設定に失敗した場合、ログに記録するか処理を中断します
+        http_response_code(500);
+        if ($DEBUG) print("Failed setting header - original: '$value', sanitized: '$sanitized_value'");
+        exit;
+      }
+    }
+
+    // コンテンツを出力
+    print($renderer->getContent());
+  } catch (Exception $e) {
+    http_response_code(500);
+    print("Internal error, please contact the admin.<br>");
+    if ($DEBUG) print($e->getMessage());
+  }
 }


### PR DESCRIPTION
## やったこと

pastebinの https://pastebin.com/6bRcqHfR のようなURLにならって、

`http://localhost:8000/67090be800854`のようなURLで特定のsnippetページに行けるようにした

#### 具体的には

- routes.phpに特定の正規表現にマッチすればshowページへ行くというコードを追加した

## なぜ

元々のルーティング設定では、'/', '/submit' など決まった文字列のpathしか対応できず、ランダムなtokenを判定してshowページに飛ばすということができなかったから