### PR TITLE
monaco エディタの導入

### DIFF
--- a/Response/Render/HTMLRenderer.php
+++ b/Response/Render/HTMLRenderer.php
@@ -44,7 +44,7 @@ class HTMLRenderer implements HTTPRenderer
 
     // バッファの内容を取得し、バッファをクリアします。
     // 取得した内容にヘッダーとフッターを追加して返します。
-    return $this->getHeader() . ob_get_clean() . $this->getFooter();
+    return $this->getHeader() . ob_get_clean();
   }
 
   private function getHeader(): string

--- a/Views/index.php
+++ b/Views/index.php
@@ -1,3 +1,24 @@
+<?php
+
+$languageOptions = [
+  'css',
+  'dockerfile',
+  'html',
+  'java',
+  'javascript',
+  'json',
+  'markdown',
+  'php',
+  'python',
+  'ruby',
+  'shell',
+  'sql',
+  'typescript',
+  'xml',
+  'yaml',
+];
+?>
+
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs/loader.js"></script>
 
 <h1>Code Sharing</h1>
@@ -5,10 +26,10 @@
 <form id="codeForm" method="post" action="/submit">
   <label for="languageSelect">Choose a programming language: </label>
   <select id="languageSelect" name="language">
-    <option value="plaintext">Plain Text</option>
-    <option value="php">PHP</option>
-    <option value="javascript">JavaScript</option>
-    <!-- Add more languages if needed -->
+    <option value="plaintext" selected>Plain Text</option>
+    <?php foreach ($languageOptions as $language) : ?>
+      <option value="<?= htmlspecialchars($language) ?>"><?= htmlspecialchars($language) ?></option>
+    <?php endforeach; ?>
   </select>
 
   <div id="editor" style="width:800px;height:600px;border:1px solid grey;"></div>

--- a/Views/index.php
+++ b/Views/index.php
@@ -1,17 +1,23 @@
-<!-- views/create.php -->
-<h1>Snippet作成 index</h1>
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs/loader.js"></script>
 
-<form method="post" action="/submit">
+<h1>Code Sharing</h1>
+
+<form id="codeForm" method="post" action="/submit">
+  <label for="languageSelect">Choose a programming language: </label>
+  <select id="languageSelect" name="language">
+    <option value="plaintext">Plain Text</option>
+    <option value="php">PHP</option>
+    <option value="javascript">JavaScript</option>
+    <!-- Add more languages if needed -->
+  </select>
+
+  <div id="editor" style="width:800px;height:600px;border:1px solid grey;"></div>
+  <input type="hidden" id="body" name="body">
+
   <label for="title">Title:</label>
   <input type="text" id="title" name="title" required>
 
-  <label for="body">Body:</label>
-  <textarea id="body" name="body" required></textarea>
-
-  <label for="language">Language:</label>
-  <input type="text" id="language" name="language" required>
-
-  <label for="expiration">Expiration:</label>
+  <label for="expiration">有効期限:</label>
   <select id="expiration" name="expiration">
     <option value="">設定しない</option>
     <option value="30seconds">30 秒</option> <!-- 開発用 -->
@@ -22,4 +28,37 @@
   </select>
 
   <button type="submit">作成</button>
+
+  <script>
+    require.config({
+      paths: {
+        'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs'
+      }
+    });
+
+    let editorInstance;
+
+    require(['vs/editor/editor.main'], function() {
+      editorInstance = monaco.editor.create(document.getElementById('editor'), {
+        value: "// Type your code here...",
+        language: 'plaintext', // Choose the language syntax you need
+        theme: 'vs-light' // Set a theme, can be 'vs-light', vs-dark or others
+      });
+
+      // Event listener for the dropdown menu to switch languages
+      document.getElementById('languageSelect').addEventListener('change', function(event) {
+        const newLanguage = event.target.value;
+        const model = editorInstance.getModel();
+
+        // Switch the language of the editor
+        monaco.editor.setModelLanguage(model, newLanguage);
+      });
+
+      document.getElementById('codeForm').addEventListener('submit', function(event) {
+        // フォーム送信前にエディターの内容を隠しフィールドに設定
+        document.getElementById('body').value = editorInstance.getValue();
+      });
+
+    });
+  </script>
 </form>

--- a/Views/index.php
+++ b/Views/index.php
@@ -21,8 +21,6 @@ $languageOptions = [
 
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs/loader.js"></script>
 
-<h1>Code Sharing</h1>
-
 <form id="codeForm" method="post" action="/submit">
   <label for="languageSelect">Choose a programming language: </label>
   <select id="languageSelect" name="language">

--- a/Views/layout/footer.php
+++ b/Views/layout/footer.php
@@ -1,1 +1,0 @@
-<div>footer</div>

--- a/Views/layout/header.php
+++ b/Views/layout/header.php
@@ -1,1 +1,2 @@
-<div>header</div>
+<h1>Code Sharing</h1>
+<!-- サイト名とlistへのリンクを表示 -->


### PR DESCRIPTION
close #8 

## やったこと

- エディターの導入
- そこから本文を登録できる
- プログラミング言語の選択とハイライト？のサポートを実行する

#### やらなかったこと

- ページ全体の簡単なデザイン調整

#### 画面

<img width="863" alt="スクリーンショット 2024-10-13 9 31 09" src="https://github.com/user-attachments/assets/5f361aec-3c1e-49bb-b206-2dc182a63665">
