### PR TITLE
snippet登録後の成功／失敗処理

### DIFF
--- a/Controllers/SnippetController.php
+++ b/Controllers/SnippetController.php
@@ -30,14 +30,16 @@ class SnippetController
 
   public function submit()
   {
-    if (!isset($_POST['title']) || !isset($_POST['body']) || !isset($_POST['language'])) {
-      echo "Error: Required fields are missing.";
-      return;
+    if (empty($_POST['title']) || empty($_POST['body']) || empty($_POST['language'])) {
+      $_SESSION['error_message'] = "Error: Required fields (title, body or language) are missing.";
+      header('Location: /');
+      exit;
     }
 
     if (Snippet::validateExpirationInput($_POST['expiration']) === false) {
-      echo "Error: Invalid expiration input." . $_POST['expiration'];
-      return;
+      $_SESSION['error_message'] = "Error: Invalid expiration input." . $_POST['expiration'];
+      header('Location: /');
+      exit;
     }
 
     $title = $_POST['title'];
@@ -57,7 +59,8 @@ class SnippetController
       // exit: セッションデータが正しく保存するために必要だった
       exit;
     } else {
-      echo "Error: Failed to save the snippet.";
+      $_SESSION['error_message'] = "Error: Failed to save the snippet.";
+      exit;
     }
   }
 

--- a/Controllers/SnippetController.php
+++ b/Controllers/SnippetController.php
@@ -6,6 +6,8 @@ namespace Controllers;
 use Models\Snippet;
 use Database\MySQLWrapper;
 
+session_start();
+
 class SnippetController
 {
   public function list()
@@ -49,7 +51,11 @@ class SnippetController
     $success = $this->saveToDatabase($snippet);
 
     if ($success) {
+      $_SESSION['snippet_token'] = $token;
+
       header('Location: /');
+      // exit: セッションデータが正しく保存するために必要だった
+      exit;
     } else {
       echo "Error: Failed to save the snippet.";
     }

--- a/Views/index.php
+++ b/Views/index.php
@@ -3,10 +3,9 @@
 session_start();
 
 $showModal = isset($_SESSION['snippet_token']);
+$createdUrl = $showModal ? BASE_URL . '/' . $_SESSION['snippet_token'] : '';
 
-if ($showModal) {
-  $createdUrl = BASE_URL . '/' . $_SESSION['snippet_token'];
-}
+$errorMessage = $_SESSION['error_message'] ?? null;
 
 $languageOptions = [
   'c',
@@ -41,6 +40,16 @@ $expirationOptions = [
 
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs/loader.js"></script>
 
+<?php if (isset($errorMessage)) : ?>
+  <div class="error-message">
+    <div class="error-text-wrapper">
+      <p><?= htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8') ?></p>
+    </div>
+  </div>
+<?php
+  unset($_SESSION['error_message']);
+endif; ?>
+
 <div class="index-container">
   <form id="codeForm" method="post" action="/submit">
     <div class="select-wrapper">
@@ -54,7 +63,7 @@ $expirationOptions = [
     </div>
 
     <div id="editor"></div>
-    <input type="hidden" id="body" name="body">
+    <input type="hidden" id="body" name="body" required>
 
     <div class="below-editor-wrapper">
       <div class="title-wrapper">

--- a/Views/index.php
+++ b/Views/index.php
@@ -1,5 +1,7 @@
 <?php
 
+session_start();
+
 $languageOptions = [
   'c',
   'cpp',
@@ -71,8 +73,28 @@ $expirationOptions = [
         <button type="submit" class="submit-button">作成</button>
       </div>
     </div>
+  </form>
 </div>
 
+<?php if (isset($_SESSION['snippet_token'])) : ?>
+  <section id="modalArea" class="modalArea">
+    <div id="modalBg" class="modalBg"></div>
+    <div class="modalWrapper">
+      <div class="modalContents">
+        <!-- 中身は後で変更 -->
+        <h1>Here are modal contents!</h1>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </p>
+        <p>Created URL: <a href="<?= htmlspecialchars($$_SESSION['snippet_token'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_SESSION['snippet_token'], ENT_QUOTES, 'UTF-8') ?></a></p>
+      </div>
+      <div id="closeModal" class="closeModal">
+        ×
+      </div>
+    </div>
+  </section>
 
+<?php
+  unset($_SESSION['snippet_token']);
+endif;
+?>
 
 <script src="/js/script.js"></script>

--- a/Views/index.php
+++ b/Views/index.php
@@ -75,37 +75,4 @@ $expirationOptions = [
 
 
 
-<script>
-  require.config({
-    paths: {
-      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs'
-    }
-  });
-
-  let editorInstance;
-
-  require(['vs/editor/editor.main'], function() {
-    editorInstance = monaco.editor.create(document.getElementById('editor'), {
-      value: "// Type your code here...",
-      language: 'plaintext', // Choose the language syntax you need
-      theme: 'vs-light', // Set a theme, can be 'vs-light', vs-dark or others
-      automaticLayout: true
-    });
-
-    // Event listener for the dropdown menu to switch languages
-    document.getElementById('languageSelect').addEventListener('change', function(event) {
-      const newLanguage = event.target.value;
-      const model = editorInstance.getModel();
-
-      // Switch the language of the editor
-      monaco.editor.setModelLanguage(model, newLanguage);
-    });
-
-    document.getElementById('codeForm').addEventListener('submit', function(event) {
-      // フォーム送信前にエディターの内容を隠しフィールドに設定
-      document.getElementById('body').value = editorInstance.getValue();
-    });
-
-  });
-</script>
-</form>
+<script src="/js/script.js"></script>

--- a/Views/index.php
+++ b/Views/index.php
@@ -2,6 +2,12 @@
 
 session_start();
 
+$showModal = isset($_SESSION['snippet_token']);
+
+if ($showModal) {
+  $createdUrl = BASE_URL . '/' . $_SESSION['snippet_token'];
+}
+
 $languageOptions = [
   'c',
   'cpp',
@@ -76,20 +82,24 @@ $expirationOptions = [
   </form>
 </div>
 
-<?php if (isset($_SESSION['snippet_token'])) : ?>
-  <section id="modalArea" class="modalArea">
-    <div id="modalBg" class="modalBg"></div>
-    <div class="modalWrapper">
-      <div class="modalContents">
-        <!-- 中身は後で変更 -->
-        <h1>Here are modal contents!</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </p>
-        <p>Created URL: <a href="<?= htmlspecialchars($$_SESSION['snippet_token'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($_SESSION['snippet_token'], ENT_QUOTES, 'UTF-8') ?></a></p>
+<?php if ($showModal) : ?>
+  <section id="modalArea" class="modal-area">
+    <div id="modalBg" class="modal-bg"></div>
+    <div class="modal-wrapper">
+      <div class="modal-contents">
+        <p class="modal-title">code を誰かに共有しよう！</p>
+
+        <div class="url-wrapper">
+          <a href="<?= htmlspecialchars($createdUrl, ENT_QUOTES, 'UTF-8') ?>"
+            id="urlLink">
+            <?= htmlspecialchars($createdUrl, ENT_QUOTES, 'UTF-8') ?>
+          </a>
+        </div>
+        <button id="copyButton" class="copy-button">URLをコピー</button>
+        <div id="closeModal" class="close-modal">
+          ×
+        </div>
       </div>
-      <div id="closeModal" class="closeModal">
-        ×
-      </div>
-    </div>
   </section>
 
 <?php

--- a/config.php
+++ b/config.php
@@ -1,3 +1,10 @@
 <?php
 
+require_once __DIR__ . '/Helpers/Settings.php';
+
+use Helpers\Settings;
+
 define('SHOW_ROUTE_PATTERN', '/([a-zA-Z0-9]{32})');
+
+$baseUrl = Settings::env('APP_ENV') === 'production' ? 'http://yourappdomain.com' : 'http://localhost:8000';
+define('BASE_URL', $baseUrl);

--- a/css/styles.css
+++ b/css/styles.css
@@ -16,9 +16,12 @@
 }
 
 .list-link {
+  padding: 10px 20px;
+}
+
+.list-link, .copy-button {
   margin-left: auto;
   display: inline-block;
-  padding: 10px 20px;
   font-size: 16px;
   color: #fff;
   background-color: #007bff;
@@ -30,7 +33,7 @@
   transition: background-color 0.3s ease;
 }
 
-.list-link:hover {
+.list-link:hover, .copy-button:hover {
   background-color: #0056b3;
 }
 
@@ -111,37 +114,56 @@
 /* modal  */
 /*        */
 
-.modalArea {
-  /* display: none; */
+.modal-area {
   position: fixed;
-  z-index: 10; /*サイトによってここの数値は調整 */
+  z-index: 10;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
 }
 
-.modalBg {
+.modal-bg {
   width: 100%;
   height: 100%;
   background-color: rgba(30,30,30,0.9);
 }
 
-.modalWrapper {
+.modal-title {
+  margin: 0 0 20px 0;
+}
+
+.modal-wrapper {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform:translate(-50%,-50%);
+  transform: translate(-50%, -50%);
   width: 70%;
-  max-width: 500px;
-  padding: 10px 30px;
+  max-width: 600px;
+  padding: 30px;
   background-color: #fff;
 }
 
-.closeModal {
+.close-modal {
   position: absolute;
   top: 0.5rem;
   right: 1rem;
   cursor: pointer;
+}
+
+.url-wrapper {
+  align-items: center;
+
+  a {
+    color: #007bff;
+    text-decoration: none;
+    margin-left: 30px;
+  }
+}
+
+/* 大多数のcss設定は上の方で list-link といっしょにやっている  */
+.copy-button {
+  margin: 20px 0 0 30px;
+  padding: 10px;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -19,7 +19,7 @@
   margin-left: auto;
   display: inline-block;
   padding: 10px 20px;
-  font-size: 16px
+  font-size: 16px;
   color: #fff;
   background-color: #007bff;
   border: none;
@@ -106,3 +106,42 @@
 .submit-button:hover {
   background-color: #4caa70;
 }
+
+/*        */
+/* modal  */
+/*        */
+
+.modalArea {
+  /* display: none; */
+  position: fixed;
+  z-index: 10; /*サイトによってここの数値は調整 */
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.modalBg {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(30,30,30,0.9);
+}
+
+.modalWrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform:translate(-50%,-50%);
+  width: 70%;
+  max-width: 500px;
+  padding: 10px 30px;
+  background-color: #fff;
+}
+
+.closeModal {
+  position: absolute;
+  top: 0.5rem;
+  right: 1rem;
+  cursor: pointer;
+}
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -41,6 +41,23 @@
 /* index  */
 /*        */
 
+.error-message {
+  background: #ec3030;
+  width: 100%;
+  height: 30px;
+  margin: 0 0 20px;
+
+  .error-text-wrapper {
+    margin: 0 auto 0;
+    width: 80%;
+
+    p {
+      text-align: center;
+      font-weight: bold;
+    }
+  }
+}
+
 .index-container {
   margin: 0 auto 200px;
   width: 80%;

--- a/js/script.js
+++ b/js/script.js
@@ -49,5 +49,22 @@ require(['vs/editor/editor.main'], function () {
     modalBg.addEventListener('click', function () {
       modal.style.display = 'none';
     });
+
+    document
+      .getElementById('copyButton')
+      .addEventListener('click', function () {
+        // コピーするテキストを取得
+        const urlText = document.getElementById('urlLink').textContent;
+
+        // クリップボードにコピー
+        navigator.clipboard
+          .writeText(urlText)
+          .then(function () {
+            alert('URLがクリップボードにコピーされました');
+          })
+          .catch(function (err) {
+            console.error('クリップボードへのコピーに失敗しました: ', err);
+          });
+      });
   }
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,34 @@
+require.config({
+  paths: {
+    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.32.1/min/vs',
+  },
+});
+
+let editorInstance;
+
+require(['vs/editor/editor.main'], function () {
+  editorInstance = monaco.editor.create(document.getElementById('editor'), {
+    value: '// Type your code here...',
+    language: 'plaintext', // Choose the language syntax you need
+    theme: 'vs-light', // Set a theme, can be 'vs-light', vs-dark or others
+    automaticLayout: true,
+  });
+
+  // Event listener for the dropdown menu to switch languages
+  document
+    .getElementById('languageSelect')
+    .addEventListener('change', function (event) {
+      const newLanguage = event.target.value;
+      const model = editorInstance.getModel();
+
+      // Switch the language of the editor
+      monaco.editor.setModelLanguage(model, newLanguage);
+    });
+
+  document
+    .getElementById('codeForm')
+    .addEventListener('submit', function (event) {
+      // フォーム送信前にエディターの内容を隠しフィールドに設定
+      document.getElementById('body').value = editorInstance.getValue();
+    });
+});

--- a/js/script.js
+++ b/js/script.js
@@ -31,4 +31,23 @@ require(['vs/editor/editor.main'], function () {
       // フォーム送信前にエディターの内容を隠しフィールドに設定
       document.getElementById('body').value = editorInstance.getValue();
     });
+
+  // ================
+  // モーダルの処理
+  // ================
+
+  const modal = document.getElementById('modalArea');
+
+  if (modal) {
+    const closeModalBtn = document.getElementById('closeModal');
+    const modalBg = document.getElementById('modalBg');
+
+    closeModalBtn.addEventListener('click', function () {
+      modal.style.display = 'none';
+    });
+
+    modalBg.addEventListener('click', function () {
+      modal.style.display = 'none';
+    });
+  }
 });


### PR DESCRIPTION
close #11 


### やったこと

- submit後に判定
  - OK
    - topページに遷移
    - modalで作成されたURLを表示（コピーボタン付き）
  - NGの場合
    - 次の内容に変更した
    - https://github.com/kashmii/recursion_snippet_share/issues/11#issuecomment-2410923756

### (注)
`Views/index.php`のscriptタグにずらっと書いていた処理は`js/script.js`に移動させた

登録成功後のモーダル


<img width="642" alt="スクリーンショット 2024-10-14 15 58 47" src="https://github.com/user-attachments/assets/3b361ad3-855a-4d5a-a916-45fa96061837">


失敗時のメッセージ表示例
<img width="895" alt="スクリーンショット 2024-10-14 21 16 47" src="https://github.com/user-attachments/assets/ca40cec0-cb02-44e6-ad24-800bd01a8368">

